### PR TITLE
Allow for Authorization URL to already contain '?'

### DIFF
--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -43,7 +43,7 @@ const authorize = (config) => {
     scope: config.scope,
     redirect_uri: config.redirect
   })
-  const popup = openPopup(config.url + '?' + query, 'oauth2')
+  const popup = openPopup(config.url + (config.url.indexOf('?') === -1 ? '?' : '&') + query, 'oauth2')
 
   return new Promise((resolve, reject) => listenForCredentials(popup, state, resolve, reject))
 }


### PR DESCRIPTION
This will allow to use an authorization URL that already contains a query string as it checks when adding the OAuth2 parameter whether a '?' is already present on the authorization URL and will use the appropriate append character