### PR TITLE
Parse 'expires_in' implicit flow response parameter

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -9,9 +9,10 @@ const loginRequest = () => ({
   type: LOGIN_REQUEST
 })
 
-const loginSuccess = (token) => ({
+const loginSuccess = (token, expires_at) => ({
   type: LOGIN_SUCCESS,
-  token
+  token,
+  expires_at
 })
 
 const loginFailure = (error) => ({
@@ -22,7 +23,7 @@ const loginFailure = (error) => ({
 export const login = (config) => (dispatch) => {
   dispatch(loginRequest())
   return authorize(config).then(
-    (token) => dispatch(loginSuccess(token)),
+    ({token, expires_at}) => dispatch(loginSuccess(token, expires_at)),
     (error) => dispatch(loginFailure(error))
   )
 }

--- a/src/actions.js
+++ b/src/actions.js
@@ -9,10 +9,10 @@ const loginRequest = () => ({
   type: LOGIN_REQUEST
 })
 
-const loginSuccess = (token, expires_at) => ({
+const loginSuccess = (token, expiresAt) => ({
   type: LOGIN_SUCCESS,
   token,
-  expires_at
+  expiresAt
 })
 
 const loginFailure = (error) => ({
@@ -23,7 +23,7 @@ const loginFailure = (error) => ({
 export const login = (config) => (dispatch) => {
   dispatch(loginRequest())
   return authorize(config).then(
-    ({token, expires_at}) => dispatch(loginSuccess(token, expires_at)),
+    ({token, expiresAt}) => dispatch(loginSuccess(token, expiresAt)),
     (error) => dispatch(loginFailure(error))
   )
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,7 @@ import { LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from './actions'
 const authMiddleware = () => (next) => (action) => {
   switch (action.type) {
     case LOGIN_SUCCESS:
-      setToken(action.token, action.expires_at)
+      setToken(action.token, action.expiresAt)
       break
     case LOGIN_FAILURE:
     case LOGOUT:

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,7 @@ import { LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from './actions'
 const authMiddleware = () => (next) => (action) => {
   switch (action.type) {
     case LOGIN_SUCCESS:
-      setToken(action.token)
+      setToken(action.token, action.expires_at)
       break
     case LOGIN_FAILURE:
     case LOGOUT:

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -23,9 +23,10 @@ const listenForCredentials = (popup, state, resolve, reject) => {
     }
 
     if (response.access_token) {
+      const expiresIn = response.expires_in ? parseInt(response.expires_in) : NaN
       const result = {
         token: response.access_token,
-        expiresAt: response.expires_in && !isNaN(response.expires_in) ? new Date().getTime() + parseInt(response.expires_in) * 1000 : null
+        expiresAt: !isNaN(expiresIn) ? new Date().getTime() + expiresIn * 1000 : null
       }
       resolve(result)
     } else {

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -23,7 +23,11 @@ const listenForCredentials = (popup, state, resolve, reject) => {
     }
 
     if (response.access_token) {
-      resolve(response.access_token)
+      const result = {
+        token: response.access_token,
+        expires_at: response.expires_in ? new Date().getTime() + parseInt(response.expires_in) * 1000 : null
+      }
+      resolve(result)
     } else {
       reject(response.error || 'Unknown error.')
     }

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -25,7 +25,7 @@ const listenForCredentials = (popup, state, resolve, reject) => {
     if (response.access_token) {
       const result = {
         token: response.access_token,
-        expires_at: response.expires_in ? new Date().getTime() + parseInt(response.expires_in) * 1000 : null
+        expiresAt: response.expires_in && !isNaN(response.expires_in) ? new Date().getTime() + parseInt(response.expires_in) * 1000 : null
       }
       resolve(result)
     } else {

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -4,7 +4,7 @@ import { LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from './actions'
 const initialState = {
   isLoggedIn: hasToken(),
   token: getToken(),
-  expires_at: getExpiresAt(),
+  expiresAt: getExpiresAt(),
   error: null
 }
 
@@ -14,21 +14,21 @@ const auth = (state = initialState, action) => {
       return Object.assign({}, state, {
         isLoggedIn: true,
         token: action.token,
-        expires_at: action.expires_at,
+        expiresAt: action.expiresAt,
         error: null
       })
     case LOGIN_FAILURE:
       return Object.assign({}, state, {
         isLoggedIn: false,
         token: null,
-        expires_at: null,
+        expiresAt: null,
         error: action.error
       })
     case LOGOUT:
       return Object.assign({}, state, {
         isLoggedIn: false,
         token: null,
-        expires_at: null,
+        expiresAt: null,
         error: null
       })
     default:

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -1,9 +1,10 @@
-import { hasToken, getToken } from './util/token'
+import { hasToken, getToken, getExpiresAt } from './util/token'
 import { LOGIN_SUCCESS, LOGIN_FAILURE, LOGOUT } from './actions'
 
 const initialState = {
   isLoggedIn: hasToken(),
   token: getToken(),
+  expires_at: getExpiresAt(),
   error: null
 }
 
@@ -13,18 +14,21 @@ const auth = (state = initialState, action) => {
       return Object.assign({}, state, {
         isLoggedIn: true,
         token: action.token,
+        expires_at: action.expires_at,
         error: null
       })
     case LOGIN_FAILURE:
       return Object.assign({}, state, {
         isLoggedIn: false,
         token: null,
+        expires_at: null,
         error: action.error
       })
     case LOGOUT:
       return Object.assign({}, state, {
         isLoggedIn: false,
         token: null,
+        expires_at: null,
         error: null
       })
     default:

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,15 +1,26 @@
 const TOKEN_KEY = 'token'
+const EXPIRES_AT_KEY = 'expires_at'
+
+export const getExpiresAt = () =>
+  window.localStorage.getItem(EXPIRES_AT_KEY) || null
 
 export const hasToken = () =>
   getToken() !== null
 
-export const getToken = () =>
-  window.localStorage.getItem(TOKEN_KEY) || null
+export const getToken = () => {
+  const expires_at = getExpiresAt()
+  if (expires_at === null || expires_at > new Date().getTime()) {
+    return window.localStorage.getItem(TOKEN_KEY) || null
+  }
+  return null
+}
 
-export const setToken = (token) => {
+export const setToken = (token, expires_at) => {
   window.localStorage.setItem(TOKEN_KEY, token)
+  window.localStorage.setItem(EXPIRES_AT_KEY, expires_at)
 }
 
 export const removeToken = () => {
   window.localStorage.removeItem(TOKEN_KEY)
+  window.localStorage.removeItem(EXPIRES_AT_KEY)
 }

--- a/src/util/token.js
+++ b/src/util/token.js
@@ -1,5 +1,5 @@
 const TOKEN_KEY = 'token'
-const EXPIRES_AT_KEY = 'expires_at'
+const EXPIRES_AT_KEY = 'expiresAt'
 
 export const getExpiresAt = () =>
   window.localStorage.getItem(EXPIRES_AT_KEY) || null
@@ -15,9 +15,9 @@ export const getToken = () => {
   return null
 }
 
-export const setToken = (token, expires_at) => {
+export const setToken = (token, expiresAt) => {
   window.localStorage.setItem(TOKEN_KEY, token)
-  window.localStorage.setItem(EXPIRES_AT_KEY, expires_at)
+  window.localStorage.setItem(EXPIRES_AT_KEY, expiresAt)
 }
 
 export const removeToken = () => {


### PR DESCRIPTION
This will allow parsing the OAuth2.0 Spec `expires_in` redirect response parameter and add it both to the local storage as well as expose it on the state.

It will actually not persist `expires_in` directly but rather persist the derived `expires_at` value as this will directly allow using it even after being read from local storage.

If the token is already expired when trying to read it from local storage it is not used but set to null instead.