### PR TITLE
Add ability to specify popup size for authentication window

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ const config = {
   url: "https://example.com/authorize",
   client: "some_client_id",
   redirect: "https://example.com/callback.html",
-  scope: "some_scope"
+  scope: "some_scope",
+  width: 400, // Width (in pixels) of login popup window. Optional, default: 400
+  height: 400 // Height (in pixels) of login popup window. Optional, default: 400
 }
 
 const Login = ({ isLoggedIn, login, logout }) => {

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -48,7 +48,10 @@ const authorize = (config) => {
     scope: config.scope,
     redirect_uri: config.redirect
   })
-  const popup = openPopup(config.url + (config.url.indexOf('?') === -1 ? '?' : '&') + query, 'oauth2')
+  const url = config.url + (config.url.indexOf('?') === -1 ? '?' : '&') + query
+  const width = config.width || 400
+  const height = config.height || 400
+  const popup = openPopup(url, 'oauth2', width, height)
 
   return new Promise((resolve, reject) => listenForCredentials(popup, state, resolve, reject))
 }

--- a/src/util/popup.js
+++ b/src/util/popup.js
@@ -10,7 +10,7 @@ const getPopupDimensions = (width, height) => {
   return `width=${width},height=${height},top=${top},left=${left}`
 }
 
-const openPopup = (url, name) =>
-  window.open(url, name, `${SETTINGS},${getPopupDimensions(400, 400)}`)
+const openPopup = (url, name, width, height) =>
+  window.open(url, name, `${SETTINGS},${getPopupDimensions(width, height)}`)
 
 export default openPopup


### PR DESCRIPTION
`width` and `height` of the authorization popup window can be specified in `config`.

The default (a 400x400 window) stays unchanged.

Addresses #7 