### PR TITLE
Added support for IG and LI

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -14,9 +14,31 @@ export const loginFailure = error => ({
   error
 })
 
-export const login = config => ({
+export const login = (
+  { 
+    url,
+    client,
+    redirect,
+    scope,
+    responseType = 'token',
+    accessTokenKey = 'access_token',
+    parseQuery = false,
+    width = 400,
+    height = 400
+  }
+) => ({
   type: LOGIN_REQUEST,
-  config
+  config: {
+    url,
+    client,
+    redirect,
+    scope,
+    responseType,
+    accessTokenKey,
+    parseQuery,
+    width,
+    height
+  }
 })
 
 export const logout = () => ({

--- a/src/oauth2.js
+++ b/src/oauth2.js
@@ -2,10 +2,24 @@ import querystring from 'query-string'
 import cuid from 'cuid'
 import openPopup from './util/popup'
 
-const listenForCredentials = (popup, state, resolve, reject) => {
+const listenForCredentials = (popup, state, resolve, reject, config) => {
   let hash
+  let credentialsFound = true
   try {
     hash = popup.location.hash
+    if (config.parseQuery) {
+      credentialsFound = false
+      const parsedQuery = querystring.parse(popup.location.search)
+      if (parsedQuery[config.accessTokenKey]) {
+        hash = hash ? hash + '&access_token=' + parsedQuery[config.accessTokenKey] : '#access_token=' + parsedQuery[config.accessTokenKey]
+      }
+      if (parsedQuery.state) {
+        hash = hash ? hash + '&state=' + parsedQuery.state : '#state=' + parsedQuery.state 
+      }
+      if (hash.includes('access_token') && hash.includes('state')) {
+        credentialsFound = true
+      }
+    }
   } catch (err) {
     if (process.env.NODE_ENV !== 'production') {
       /* eslint-disable no-console */
@@ -14,7 +28,7 @@ const listenForCredentials = (popup, state, resolve, reject) => {
     }
   }
 
-  if (hash) {
+  if (hash && credentialsFound) {
     popup.close()
 
     const response = querystring.parse(hash.substr(1))
@@ -37,7 +51,7 @@ const listenForCredentials = (popup, state, resolve, reject) => {
   } else if (popup.closed) {
     reject('Authentication was cancelled.')
   } else {
-    setTimeout(() => listenForCredentials(popup, state, resolve, reject), 100)
+    setTimeout(() => listenForCredentials(popup, state, resolve, reject, config), 100)
   }
 }
 
@@ -45,7 +59,7 @@ const authorize = config => {
   const state = cuid()
   const query = querystring.stringify({
     state,
-    response_type: 'token',
+    response_type: config.responseType,
     client_id: config.client,
     scope: config.scope,
     redirect_uri: config.redirect
@@ -56,7 +70,7 @@ const authorize = config => {
   const popup = openPopup(url, 'oauth2', width, height)
 
   return new Promise((resolve, reject) =>
-    listenForCredentials(popup, state, resolve, reject)
+    listenForCredentials(popup, state, resolve, reject, config)
   )
 }
 


### PR DESCRIPTION
In this PR, I added support for logging in via Instagram and Linkedin since these two behave differently compared to facebook where it responds with access_token and state as hash parameters. Linkedin returns both as query parameters (it also returns code instead of access_token) and IG returns the access token as a hash parameter but the state is actually a query parameter.